### PR TITLE
Types and some EJB spec related fixes

### DIFF
--- a/Chapter02-EnablingTechnologies.asciidoc
+++ b/Chapter02-EnablingTechnologies.asciidoc
@@ -658,7 +658,7 @@ Maven.resolver().loadPomFromClassLoaderResource("/path/to/pom.xml")
   .resolve("G:A:P:?").withTransitivity().asFile();
 ----
 
-2. Resolving artifacts defined in effective POM. ShrinkWrap Resolvers allows you to artifacts defined with specific scope into list of artifacts to be resolved. This way, you don't need to alter your tests if you change dependencies of your application. You can either use +importDependencies(ScopeType...)+ or convenience methods, that cover the most frequent usages (+importRuntimeDependencies()+, +importTestDependencies()+ and +importRuntimeAndTestDependencies()+:
+2. Resolving artifacts defined in effective POM. ShrinkWrap Resolvers allows you to artifacts defined with specific scope into list of artifacts to be resolved. This way, you don't need to alter your tests if you change dependencies of your application. You can either use +importDependencies(ScopeType...)+ or convenience methods, that cover the most frequent usages (+importRuntimeDependencies()+, +importTestDependencies()+ and +importRuntimeAndTestDependencies())+:
 +
 [source,java]
 ----

--- a/Chapter04-RequirementsAndExampleApplication.asciidoc
+++ b/Chapter04-RequirementsAndExampleApplication.asciidoc
@@ -210,7 +210,7 @@ image:images/ch04-requirements_example_app/clone.png["GitHub URI to Clone"]
 Then simply move to a directory in which you'd like to place your local clone, and issue the +git clone+ command, passing in the URI to your GitHub repository.  For instance:
 
 ----
-$> git clone git@github.com:ALRubinger/continuous-enterprise-development.git
+$> git clone git@github.com:arquillian/continuous-enterprise-development.git
 Cloning into 'continuous-enterprise-development'...
 remote: Counting objects: 2661, done.
 remote: Compressing objects: 100% (1170/1170), done.

--- a/Chapter07-BusinessLogicServicesLayer.asciidoc
+++ b/Chapter07-BusinessLogicServicesLayer.asciidoc
@@ -50,7 +50,7 @@ Web-based applications offer few avenues to push information to their users once
 
 Our GeekSeek application will therefore introduce the requirement: "Send an Email to the new User upon successful Signup"
 
-At first blush, this seems like a farily trivial problems to solve.  The http://www.oracle.com/technetwork/java/javamail/index.html[JavaMail] API is straightforward enough to use (though a bit dated), and is included as part of the Java EE platform.
+At first blush, this seems like a fairly trivial problems to solve.  The http://www.oracle.com/technetwork/java/javamail/index.html[JavaMail] API is straightforward enough to use (though a bit dated), and is included as part of the Java EE platform.
 
 Unfortunately, there are many issues to consider beyond the boilerplate code required to send the email itself.
 
@@ -58,7 +58,7 @@ _Should we block (wait) while the mail message is sent to the SMTP server?_ Conn
 
 _What if sending the email fails?  Should the enclosing user registration action which called the email service fail, too?_  Sending the email is, in our case, part of a welcome operation.  A new user registration doesn't strictly *need* this to succeed as we won't be relying upon email to validate the user's identity.  Still, we'd like to make every available effort to ensure that the email goes through, independent of the user registration action.  And we'd like to have some notification and options to handle emails that were attempted to be sent, but have failed.
 
-_How do we test to ensure that the emails we've sent are received?  How do we validate the email's contents are correct?_  Even if we don't dispatch the communication with the SMTP server to a new Thread, interacting with this external process makes for an asynchronous action.  Asynchronous testing is not always the most simple process to set up, but this does not excuse us from the responsibility of ensuring that our email service is worked as designed.
+_How do we test to ensure that the emails we've sent are received?  How do we validate the email's contents are correct?_  Even if we don't dispatch the communication with the SMTP server to a new Thread, interacting with this external process makes for an asynchronous action.  Asynchronous testing is not always the most simple process to set up, but this does not excuse us from the responsibility of ensuring that our email service is working as designed.
 
 === Implementation
 
@@ -120,7 +120,7 @@ public MailMessage build() throws IllegalStateException {
 
 It's this immutable +MailMessageBuilder.MailMessage+ which will be safely passed between our services.
 
-With our value object defined, we can now create our +SMTPMailService+.  We know that we'll need to connect to some external SMTP server via the +JavaMail+ API, and Java EE allows injection of these via the +@Resource+ annotation (though the mechanics of exactly where some services are bound is vendor-dependent.).  Also, we know that this +SMTPMailService+ is meant to be shared by all users running the application, and won't have any session-specific state.  For these reasons, we'll implement the +SMTPMailService+ as a Singleton Session EJB.  Note that a a Stateless Session Bean (for use of a pool of instances) might work in an equally-appropriate fashion.
+With our value object defined, we can now create our +SMTPMailService+.  We know that we'll need to connect to some external SMTP server via the +JavaMail+ API, and Java EE allows injection of these via the +@Resource+ annotation (though the mechanics of exactly where some services are bound is vendor-dependent.).  Also, we know that this +SMTPMailService+ is meant to be shared by all users running the application, and won't have any session-specific state.  For these reasons, we'll implement the +SMTPMailService+ as a Singleton Session EJB.  Note that a Stateless Session Bean (for use of a pool of instances) might work in an equally-appropriate fashion.
 
 [source,java]
 ----
@@ -134,7 +134,7 @@ The above is our Singleton bean declaration.  Of particular note is the +Transac
 
 An SMTP server is an external resource which is not transactionally-aware.  Therefore, we'll have to make note of any exceptions and ensure that if we want a transaction rolled back, we either explicitly tell that to the +TransactionManager+ or throw an unchecked exception which will signal the EJB container to mark any currently-executing transaction for rollback.
 
-We're making a general-purpose SMTP service here, so we may not always know the appropriate actions to take with regards to transactions.  The default for EJB is +@TransactionAttributeType.MANDATORY+, which creates a transaction if one is not already in flight.  That's not really appropriate here; the SMTP server with which we interact is not transactional, it it'd be silly to sacrifice the overhead of starting a transaction when we're not even dealing with a resource which will respect its semantics!  +@TransactionAttributeType.SUPPORTS+, which we've used here, will accept existing transactions if one is in play, or do nothing if we're invoked outside of a transactional context.
+We're making a general-purpose SMTP service here, so we may not always know the appropriate actions to take with regards to transactions.  The default for EJB is +@TransactionAttributeType.REQUIRED+, which creates a transaction if one is not already in flight.  That's not really appropriate here; the SMTP server with which we interact is not transactional, it it'd be silly to sacrifice the overhead of starting a transaction when we're not even dealing with a resource which will respect its semantics!  +@TransactionAttributeType.SUPPORTS+, which we've used here, will accept existing transactions if one is in play, or do nothing if we're invoked outside of a transactional context.
 
 Now we need to define a method to do the dirty work: accept our +MailMessage+ as a parameter and send it along to the SMTP server.  The +JavaMail+ API will act as our conduit to connect to the SMTP server, so we'll take advantage of Java EE's +@Resource+ annotation to inject some relevant supporting services into our +SMTPMailService+.
 
@@ -244,7 +244,7 @@ public void queueMailForDelivery(final MailMessageBuilder.MailMessage mailMessag
     try {
         final Connection connection = connectionFactory.createConnection();
         final javax.jms.Session session = connection
-          .createSession(false, javax.jms.Session.AUTO_ACKNOWLEDGE);
+          .createSession(true, javax.jms.Session.SESSION_TRANSACTED);
         final MessageProducer producer = session.createProducer(smtpQueue);
         final ObjectMessage jmsMessage = session.createObjectMessage(mailMessage);
         producer.send(jmsMessage);

--- a/code/application/application/pom.xml
+++ b/code/application/application/pom.xml
@@ -88,6 +88,18 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
+          <artifactId>httpmime</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>httpcore</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>httpclient</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
+        </exclusion>
+        <exclusion>
           <groupId>org.codehaus.jackson</groupId>
           <artifactId>jackson-mapper-asl</artifactId>
         </exclusion>

--- a/code/application/application/src/test/java/org/cedj/geekseek/test/functional/arquillian/AngularJSDroneExtension.java
+++ b/code/application/application/src/test/java/org/cedj/geekseek/test/functional/arquillian/AngularJSDroneExtension.java
@@ -4,7 +4,8 @@ import java.lang.annotation.Annotation;
 import java.util.concurrent.TimeUnit;
 
 import org.jboss.arquillian.core.spi.LoadableExtension;
-import org.jboss.arquillian.drone.spi.Enhancer;
+import org.jboss.arquillian.drone.spi.DroneInstanceEnhancer;
+import org.jboss.arquillian.drone.spi.InstanceOrCallableInstance;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -16,10 +17,10 @@ public class AngularJSDroneExtension implements LoadableExtension {
 
     @Override
     public void register(ExtensionBuilder builder) {
-        builder.service(Enhancer.class, AngularJSEnhancer.class);
+        builder.service(DroneInstanceEnhancer.class, AngularJSEnhancer.class);
     }
 
-    public static class AngularJSEnhancer implements Enhancer<WebDriver> {
+    public static class AngularJSEnhancer implements DroneInstanceEnhancer<WebDriver> {
 
         private WebDriverEventListener listener;
 
@@ -29,8 +30,9 @@ public class AngularJSDroneExtension implements LoadableExtension {
         }
 
         @Override
-        public boolean canEnhance(Class<?> type, Class<? extends Annotation> qualifier) {
-            return WebDriver.class.isAssignableFrom(type);
+        public boolean canEnhance(InstanceOrCallableInstance instance,
+				Class<?> droneType, Class<? extends Annotation> qualifier) {
+		            return WebDriver.class.isAssignableFrom(droneType);
         }
 
         @Override

--- a/code/application/application/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/code/application/application/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,2 +1,2 @@
-cedj.geekseek.test.functional.arquillian.ArquillianSuiteExtension
-cedj.geekseek.test.functional.arquillian.AngularJSDroneExtension
+org.cedj.geekseek.test.functional.arquillian.ArquillianSuiteExtension
+org.cedj.geekseek.test.functional.arquillian.AngularJSDroneExtension

--- a/code/application/pom.xml
+++ b/code/application/pom.xml
@@ -42,12 +42,12 @@
 
     <version.arquillian_core>1.1.1.Final</version.arquillian_core>
     <version.arquillian_persistence>1.0.0.Alpha6</version.arquillian_persistence>
-    <version.arquillian_drone>1.2.0.Beta2</version.arquillian_drone>
-    <version.arquillian_graphene>2.0.0.Beta2</version.arquillian_graphene>
+    <version.arquillian_drone>1.2.1.Final</version.arquillian_drone>
+    <version.arquillian_graphene>2.0.0.Final</version.arquillian_graphene>
     <version.arquillian_warp>1.0.0.Beta1-SNAPSHOT</version.arquillian_warp>
     <version.arquillian_warp_rest>1.0.0.Final-SNAPSHOT</version.arquillian_warp_rest>
     <version.arquillian_qunit>1.0.0.Alpha1</version.arquillian_qunit>
-    <version.restassured>1.8.1</version.restassured>
+    <version.restassured>2.3.0</version.restassured>
     <version.wildfly>8.0.0.Beta1</version.wildfly>
     <version.jboss_as>7.1.1.Final</version.jboss_as>
     <version.jboss_eap>7.2.0.Final</version.jboss_eap>
@@ -712,31 +712,6 @@
       </dependencies>
       <build>
         <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>unpack</id>
-                <phase>process-test-classes</phase>
-                <goals>
-                  <goal>unpack</goal>
-                </goals>
-                <configuration>
-                  <artifactItems>
-                    <artifactItem>
-                      <groupId>org.wildfly</groupId>
-                      <artifactId>wildfly-dist</artifactId>
-                      <version>${version.wildfly}</version>
-                      <type>zip</type>
-                      <overWrite>false</overWrite>
-                      <outputDirectory>${project.build.directory}</outputDirectory>
-                    </artifactItem>
-                  </artifactItems>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>

--- a/code/application/pom.xml
+++ b/code/application/pom.xml
@@ -713,6 +713,31 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack</id>
+                <phase>process-test-classes</phase>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.wildfly</groupId>
+                      <artifactId>wildfly-dist</artifactId>
+                      <version>${version.wildfly}</version>
+                      <type>zip</type>
+                      <overWrite>false</overWrite>
+                      <outputDirectory>${project.build.directory}</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <environmentVariables>

--- a/code/application/pom.xml
+++ b/code/application/pom.xml
@@ -48,7 +48,7 @@
     <version.arquillian_warp_rest>1.0.0.Final-SNAPSHOT</version.arquillian_warp_rest>
     <version.arquillian_qunit>1.0.0.Alpha1</version.arquillian_qunit>
     <version.restassured>2.3.0</version.restassured>
-    <version.wildfly>8.0.0.Beta1</version.wildfly>
+    <version.wildfly>8.0.0.Final</version.wildfly>
     <version.jboss_as>7.1.1.Final</version.jboss_as>
     <version.jboss_eap>7.2.0.Final</version.jboss_eap>
     <version.jboss_eap_managed>eap-6.1.0</version.jboss_eap_managed>

--- a/code/application/service/security/pom.xml
+++ b/code/application/service/security/pom.xml
@@ -106,6 +106,24 @@
       <groupId>org.jboss.shrinkwrap.resolver</groupId>
       <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>httpmime</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>httpcore</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>httpclient</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-mapper-asl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.shrinkwrap.descriptors</groupId>
@@ -127,6 +145,24 @@
       <groupId>com.jayway.restassured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>httpmime</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>httpcore</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>httpclient</artifactId>
+          <groupId>org.apache.httpcomponents</groupId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-mapper-asl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/code/application/service/security/src/test/java/org/cedj/geekseek/service/security/test/functional/TwitterAuthLoginTestCase.java
+++ b/code/application/service/security/src/test/java/org/cedj/geekseek/service/security/test/functional/TwitterAuthLoginTestCase.java
@@ -27,7 +27,7 @@ public class TwitterAuthLoginTestCase {
     @Deployment(testable = false)
     public static WebArchive deploy() {
         return ShrinkWrap.create(WebArchive.class)
-            //.addAsResource("auth.properties")
+            .addAsResource("Twitter.properties")
             .addPackages(false,
                 AuthServlet.class.getPackage(),
                 OAuthAuthenticator.class.getPackage(),

--- a/code/application/service/security/src/test/java/org/cedj/geekseek/service/security/test/integration/WhoAmIResourceTestCase.java
+++ b/code/application/service/security/src/test/java/org/cedj/geekseek/service/security/test/integration/WhoAmIResourceTestCase.java
@@ -14,6 +14,7 @@ import org.cedj.geekseek.service.security.rest.WhoAmIResource;
 import org.cedj.geekseek.service.security.test.model.SetupAuth;
 import org.cedj.geekseek.service.security.test.model.TestApplication;
 import org.cedj.geekseek.service.security.test.model.TestCurrentUserProducer;
+import org.cedj.geekseek.service.security.test.model.TestUserRepository;
 import org.cedj.geekseek.web.rest.core.test.integration.RestCoreDeployments;
 import org.cedj.geekseek.web.rest.user.test.integration.UserRestDeployments;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -40,7 +41,8 @@ public class WhoAmIResourceTestCase {
                 WhoAmIResource.class,
                 SetupAuth.class,
                 TestApplication.class,
-                TestCurrentUserProducer.class)
+                TestCurrentUserProducer.class,
+                TestUserRepository.class)
             .addAsLibraries(RestCoreDeployments.root())
             .addAsLibraries(UserDeployments.domain())
             .addAsLibraries(UserRestDeployments.module())

--- a/code/application/service/security/src/test/java/org/cedj/geekseek/service/security/test/model/TestUserRepository.java
+++ b/code/application/service/security/src/test/java/org/cedj/geekseek/service/security/test/model/TestUserRepository.java
@@ -1,0 +1,26 @@
+package org.cedj.geekseek.service.security.test.model;
+
+import org.cedj.geekseek.domain.Repository;
+import org.cedj.geekseek.domain.user.model.User;
+
+public class TestUserRepository implements Repository<User> {
+
+	@Override
+	public Class<User> getType() {
+		return null;
+	}
+
+	@Override
+	public User store(User entity) {
+		return null;
+	}
+
+	@Override
+	public User get(String id) {
+		return null;
+	}
+
+	@Override
+	public void remove(User entity) {
+	}
+}


### PR DESCRIPTION
Hard to find the diff, but in line 123 was a duplicate "a"

Line 137: EJB 3.1 states in 13.3.7 that the default transaction attribute is REQUIRED. Nevertheless the rest of the description seems to be correct;-)

Line 247: EJB 3.1 recommends in 13.3.5 to use transacted=true and acknowledgeMode=SESSION_TRANSACTED when creating a JMS session as messages are sent with the commit anyway.
